### PR TITLE
style: insert commas for disable number rounding

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
@@ -3000,7 +3000,7 @@ public class LocaleController {
             if (rounded != null) {
                 rounded[0] = number;
             }
-            return String.valueOf(number);
+            return String.format("%,d", number);
         }
         StringBuilder K = new StringBuilder();
         int lastDec = 0;


### PR DESCRIPTION
Exteragram/AyuGram do insert commas, it looks better to insert them.
<img width="1080" height="2340" alt="Screenshot_20260824_182024_AyuGram" src="https://github.com/user-attachments/assets/352f5c86-1b7e-46f2-9cda-6ecf85c4ad0b" />

FYI: It is merged in Nagram: https://github.com/NextAlone/Nagram/commit/99b63a4428a79ee7cf83e7ac9b1504f6951bf971