### PR TITLE
feat(auth): add optional email code prioritization and fast resend countdown bypass

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/tgnet/TLRPC.java
+++ b/TMessagesProj/src/main/java/org/telegram/tgnet/TLRPC.java
@@ -18322,6 +18322,7 @@ public class TLRPC {
 
         public int flags;
         public boolean allow_flashcall;
+        public boolean request_email_code;
         public boolean current_number;
         public boolean allow_app_hash;
         public boolean allow_missed_call;
@@ -18339,6 +18340,7 @@ public class TLRPC {
         public void readParams(InputSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
             allow_flashcall = hasFlag(flags, FLAG_0);
+            request_email_code = hasFlag(flags, FLAG_0);
             current_number = hasFlag(flags, FLAG_1);
             allow_app_hash = hasFlag(flags, FLAG_4);
             allow_missed_call = hasFlag(flags, FLAG_5);
@@ -18355,7 +18357,7 @@ public class TLRPC {
 
         public void serializeToStream(OutputSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = setFlag(flags, FLAG_0, allow_flashcall);
+            flags = setFlag(flags, FLAG_0, allow_flashcall || request_email_code || hasFlag(flags, FLAG_0));
             flags = setFlag(flags, FLAG_1, current_number);
             flags = setFlag(flags, FLAG_4, allow_app_hash);
             flags = setFlag(flags, FLAG_5, allow_missed_call);

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -1815,6 +1815,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
 
     private boolean isRequestingFirebaseSms;
     private void fillNextCodeParams(Bundle params, TLRPC.auth_SentCode res, boolean animate) {
+        FileLog.d("LoginAuth: received sentCode type=" + (res.type != null ? res.type.getClass().getSimpleName() : "null") + ", next_type=" + (res.next_type != null ? res.next_type.getClass().getSimpleName() : "null") + ", timeout=" + res.timeout);
         if (res instanceof TLRPC.TL_auth_sentCodePaymentRequired) {
             final TLRPC.TL_auth_sentCodePaymentRequired auth = (TLRPC.TL_auth_sentCodePaymentRequired) res;
             params.putString("product", auth.store_product);
@@ -3286,11 +3287,13 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
             if (currentCountry != null) {
                 params.putString("country", currentCountry.code);
             }
+            params.putBoolean("prioritizeEmailCode", prioritizeEmailCode);
             nextPressed = true;
             PhoneInputData phoneInputData = new PhoneInputData();
             phoneInputData.phoneNumber = "+" + codeField.getText() + " " + phoneField.getText();
             phoneInputData.country = currentCountry;
             phoneInputData.patterns = phoneFormatMap.get(codeField.getText().toString());
+            FileLog.d("LoginAuth: sending auth_sendCode for phone=" + phone + ", request_email_code=" + settings.request_email_code);
             int reqId = ConnectionsManager.getInstance(currentAccount).sendRequest(req, (response, error) -> AndroidUtilities.runOnUIThread(() -> {
                 nextPressed = false;
                 if (error == null) {
@@ -3731,6 +3734,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
         @AuthType
         private int prevType;
 
+        private boolean prioritizeEmailCode;
         private boolean isResendingCode = false;
 
         private String pattern = "*";
@@ -4090,7 +4094,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
                         return;
                     }
                     boolean email = nextType == 0;
-                    if (!email) {
+                    if (!email || prioritizeEmailCode) {
                         if (radialProgressView.getTag() != null) {
                             return;
                         }
@@ -4319,15 +4323,18 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
             params.putString("ephone", emailPhone);
             params.putString("phoneFormated", requestPhone);
             params.putInt("prevType", currentType);
+            params.putBoolean("prioritizeEmailCode", prioritizeEmailCode);
 
             nextPressed = true;
 
             TLRPC.TL_auth_resendCode req = new TLRPC.TL_auth_resendCode();
             req.phone_number = requestPhone;
             req.phone_code_hash = phoneHash;
+            FileLog.d("LoginAuth: calling auth_resendCode for phone=" + requestPhone + ", prioritizeEmailCode=" + prioritizeEmailCode);
             int reqId = ConnectionsManager.getInstance(currentAccount).sendRequest(req, (response, error) -> AndroidUtilities.runOnUIThread(() -> {
                 nextPressed = false;
                 if (error == null) {
+                    FileLog.d("LoginAuth: auth_resendCode success, response type=" + (response instanceof TLRPC.TL_auth_sentCode && ((TLRPC.TL_auth_sentCode) response).type != null ? ((TLRPC.TL_auth_sentCode) response).type.getClass().getSimpleName() : "null"));
                     nextCodeParams = params;
                     nextCodeAuth = (TLRPC.TL_auth_sentCode) response;
                     if (nextCodeAuth.type instanceof TLRPC.TL_auth_sentCodeTypeSmsPhrase) {
@@ -4337,6 +4344,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
                     }
                     fillNextCodeParams(nextCodeParams, nextCodeAuth);
                 } else {
+                    FileLog.d("LoginAuth: auth_resendCode error=" + error.text + " code=" + error.code);
                     if (error.text != null) {
                         if (error.text.contains("PHONE_NUMBER_INVALID")) {
                             needShowAlert(getString(R.string.RestorePasswordNoEmailTitle), getString(R.string.InvalidPhoneNumber));
@@ -4492,6 +4500,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
             prefix = params.getString("prefix");
             length = params.getInt("length");
             prevType = params.getInt("prevType", 0);
+            prioritizeEmailCode = params.getBoolean("prioritizeEmailCode", false);
             if (length == 0) {
                 length = 5;
             }
@@ -4576,7 +4585,9 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
 
             if (currentType != AUTH_TYPE_FRAGMENT_SMS) {
                 if (currentType == AUTH_TYPE_MESSAGE) {
-                    if (nextType == AUTH_TYPE_FLASH_CALL || nextType == AUTH_TYPE_CALL || nextType == AUTH_TYPE_MISSED_CALL) {
+                    if (prioritizeEmailCode) {
+                        problemText.setText(getString(R.string.SendCodeViaEmail));
+                    } else if (nextType == AUTH_TYPE_FLASH_CALL || nextType == AUTH_TYPE_CALL || nextType == AUTH_TYPE_MISSED_CALL) {
                         problemText.setText(getString(R.string.DidNotGetTheCodePhone));
                     } else if (nextType == AUTH_TYPE_FRAGMENT_SMS) {
                         problemText.setText(getString(R.string.DidNotGetTheCodeFragment));

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -2027,6 +2027,8 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
         private ImageView chevronRight;
         private CheckBoxCell syncContactsBox;
         private CheckBoxCell testBackendCheckBox;
+        private CheckBoxCell prioritizeEmailCheckBox;
+        private boolean prioritizeEmailCode = false;
 
         @CountryState
         private int countryState = COUNTRY_STATE_NOT_SET_OR_VALID;
@@ -2532,6 +2534,21 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
                     } else {
                         BulletinFactory.of(slideViewsContainer, null).createSimpleBulletin(R.raw.contacts_sync_off, getString("SyncContactsOff", R.string.SyncContactsOff)).show();
                     }
+                });
+            }
+
+            if (activityMode == MODE_LOGIN) {
+                prioritizeEmailCheckBox = new CheckBoxCell(context, 2);
+                prioritizeEmailCheckBox.setText(getString(R.string.PrioritizeEmailCode), "", prioritizeEmailCode, false);
+                addView(prioritizeEmailCheckBox, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.MATCH_PARENT, Gravity.LEFT | Gravity.TOP, 16, 0, 16 + (LocaleController.isRTL && AndroidUtilities.isSmallScreen() ? 56 : 0), 0));
+                bottomMargin -= 24;
+                prioritizeEmailCheckBox.setOnClickListener(v -> {
+                    if (getParentActivity() == null) {
+                        return;
+                    }
+                    CheckBoxCell cell = (CheckBoxCell) v;
+                    prioritizeEmailCode = !prioritizeEmailCode;
+                    cell.setChecked(prioritizeEmailCode, true);
                 });
             }
 
@@ -3168,6 +3185,10 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
             }
 
             TLRPC.TL_codeSettings settings = new TLRPC.TL_codeSettings();
+            if (prioritizeEmailCode) {
+                settings.request_email_code = true;
+                settings.flags |= 1;
+            }
             settings.allow_flashcall = simcardAvailable && allowCall && allowCancelCall && allowReadCallLog;
             settings.allow_missed_call = simcardAvailable && allowCall;
             settings.allow_app_hash = settings.allow_firebase = PushListenerController.getProvider().hasServices();
@@ -3896,7 +3917,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
                 }
                 @Override
                 protected boolean isRippleEnabled() {
-                    return getVisibility() == View.VISIBLE && !(time > 0 && timeTimer != null);
+                    return getVisibility() == View.VISIBLE;
                 }
             };
             timeText.setLinkTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteValueText));
@@ -3905,10 +3926,25 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
             timeText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
             timeText.setGravity(Gravity.TOP | Gravity.LEFT);
             timeText.setOnClickListener(v -> {
-//                if (isRequestingFirebaseSms || isResendingCode) {
-//                    return;
-//                }
+                if (isRequestingFirebaseSms || isResendingCode) {
+                    return;
+                }
                 if (time > 0 && timeTimer != null) {
+                    if (getParentActivity() != null) {
+                        AlertDialog.Builder builder = new AlertDialog.Builder(getParentActivity());
+                        builder.setTitle(getString(R.string.FastResendDialogTitle));
+                        builder.setMessage(getString(R.string.FastResendDialogMessage));
+                        builder.setPositiveButton(getString(R.string.FastResendNow), (dialog, which) -> {
+                            destroyTimer();
+                            time = 0;
+                            isResendingCode = true;
+                            timeText.invalidate();
+                            timeText.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteValueText));
+                            resendCode();
+                        });
+                        builder.setNegativeButton(getString(R.string.Cancel), null);
+                        showDialog(builder.create());
+                    }
                     return;
                 }
                 isResendingCode = true;

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -4093,6 +4093,14 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
                     if (nextPressed || timeText != null && timeText.getVisibility() != View.GONE || isResendingCode) {
                         return;
                     }
+                    if (currentType == AUTH_TYPE_MESSAGE && nextType == 0) {
+                        new AlertDialog.Builder(context)
+                                .setTitle(getString(R.string.CodeSentToOtherDeviceTitle))
+                                .setMessage(AndroidUtilities.replaceTags(getString(R.string.CodeSentToOtherDeviceInfo)))
+                                .setPositiveButton(getString(R.string.OK), null)
+                                .show();
+                        return;
+                    }
                     boolean email = nextType == 0;
                     if (!email || prioritizeEmailCode) {
                         if (radialProgressView.getTag() != null) {
@@ -4356,6 +4364,8 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
                             needShowAlert(getString(R.string.RestorePasswordNoEmailTitle), getString(R.string.CodeExpired));
                         } else if (error.text.startsWith("FLOOD_WAIT")) {
                             needShowAlert(getString(R.string.RestorePasswordNoEmailTitle), getString(R.string.FloodWait) + "\n" + error.text);
+                        } else if (error.text.contains("SEND_CODE_UNAVAILABLE")) {
+                            needShowAlert(getString(R.string.RestorePasswordNoEmailTitle), getString(R.string.SendCodeUnavailableInfo));
                         } else if (error.code != -1000) {
                             needShowAlert(getString(R.string.RestorePasswordNoEmailTitle), getString(R.string.ErrorOccurred) + "\n" + error.text);
                         }
@@ -4585,16 +4595,14 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
 
             if (currentType != AUTH_TYPE_FRAGMENT_SMS) {
                 if (currentType == AUTH_TYPE_MESSAGE) {
-                    if (prioritizeEmailCode) {
-                        problemText.setText(getString(R.string.SendCodeViaEmail));
-                    } else if (nextType == AUTH_TYPE_FLASH_CALL || nextType == AUTH_TYPE_CALL || nextType == AUTH_TYPE_MISSED_CALL) {
+                    if (nextType == AUTH_TYPE_FLASH_CALL || nextType == AUTH_TYPE_CALL || nextType == AUTH_TYPE_MISSED_CALL) {
                         problemText.setText(getString(R.string.DidNotGetTheCodePhone));
                     } else if (nextType == AUTH_TYPE_FRAGMENT_SMS) {
                         problemText.setText(getString(R.string.DidNotGetTheCodeFragment));
                     } else if (nextType == 0) {
                         problemText.setText(getString(R.string.DidNotGetTheCode));
                     } else {
-                        problemText.setText(getString(R.string.DidNotGetTheCodeSms));
+                        problemText.setText(prioritizeEmailCode ? getString(R.string.SendCodeViaEmail) : getString(R.string.DidNotGetTheCodeSms));
                     }
                 } else {
                     problemText.setText(getString(R.string.DidNotGetTheCode));

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_nia.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_nia.xml
@@ -560,6 +560,7 @@
     <string name="AlreadyFastestProxy">当前已在使用最快代理</string>
 
     <string name="PrioritizeEmailCode">优先使用邮箱接收验证码</string>
+    <string name="SendCodeViaEmail">通过邮箱发送验证码</string>
     <string name="FastResendDialogTitle">重新发送验证码</string>
     <string name="FastResendDialogMessage">尚未收到验证码？是否跳过等待倒计时并立即重新发送？</string>
     <string name="FastResendNow">立即重发</string>

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_nia.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_nia.xml
@@ -558,4 +558,9 @@
     <string name="UseFastestProxy">切换至最快代理</string>
     <string name="SwitchedToFastestProxy">已切换至最快代理</string>
     <string name="AlreadyFastestProxy">当前已在使用最快代理</string>
+
+    <string name="PrioritizeEmailCode">优先使用邮箱接收验证码</string>
+    <string name="FastResendDialogTitle">重新发送验证码</string>
+    <string name="FastResendDialogMessage">尚未收到验证码？是否跳过等待倒计时并立即重新发送？</string>
+    <string name="FastResendNow">立即重发</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_nia.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_nia.xml
@@ -564,4 +564,7 @@
     <string name="FastResendDialogTitle">重新发送验证码</string>
     <string name="FastResendDialogMessage">尚未收到验证码？是否跳过等待倒计时并立即重新发送？</string>
     <string name="FastResendNow">立即重发</string>
+    <string name="CodeSentToOtherDeviceTitle">查看您的 Telegram 应用</string>
+    <string name="CodeSentToOtherDeviceInfo">登录验证码已发送至您其他设备上的 Telegram 应用。\n\n提示：如需通过邮箱接收验证码，请先在 Telegram 官方应用的“设置 > 隐私与安全 > 两步验证”中绑定“登录邮箱”。</string>
+    <string name="SendCodeUnavailableInfo">Telegram 目前无法通过其他途径发送验证码。若您其他设备已登录，请查看该设备收到的应用内验证码。\n\n如需使用邮箱登录，请确保已在 Telegram 的隐私与安全设置中绑定“登录邮箱”。</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-zh-rTW/strings_nia.xml
+++ b/TMessagesProj/src/main/res/values-zh-rTW/strings_nia.xml
@@ -560,6 +560,7 @@
     <string name="AlreadyFastestProxy">目前已在使用最快代理</string>
 
     <string name="PrioritizeEmailCode">優先使用郵箱接收驗證碼</string>
+    <string name="SendCodeViaEmail">透過郵箱發送驗證碼</string>
     <string name="FastResendDialogTitle">重新發送驗證碼</string>
     <string name="FastResendDialogMessage">尚未收到驗證碼？是否跳過等待倒計時並立即重新發送？</string>
     <string name="FastResendNow">立即重發</string>

--- a/TMessagesProj/src/main/res/values-zh-rTW/strings_nia.xml
+++ b/TMessagesProj/src/main/res/values-zh-rTW/strings_nia.xml
@@ -558,4 +558,9 @@
     <string name="UseFastestProxy">切換至最快代理</string>
     <string name="SwitchedToFastestProxy">已切換至最快代理</string>
     <string name="AlreadyFastestProxy">目前已在使用最快代理</string>
+
+    <string name="PrioritizeEmailCode">優先使用郵箱接收驗證碼</string>
+    <string name="FastResendDialogTitle">重新發送驗證碼</string>
+    <string name="FastResendDialogMessage">尚未收到驗證碼？是否跳過等待倒計時並立即重新發送？</string>
+    <string name="FastResendNow">立即重發</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-zh-rTW/strings_nia.xml
+++ b/TMessagesProj/src/main/res/values-zh-rTW/strings_nia.xml
@@ -564,4 +564,7 @@
     <string name="FastResendDialogTitle">重新發送驗證碼</string>
     <string name="FastResendDialogMessage">尚未收到驗證碼？是否跳過等待倒計時並立即重新發送？</string>
     <string name="FastResendNow">立即重發</string>
+    <string name="CodeSentToOtherDeviceTitle">查看您的 Telegram 應用</string>
+    <string name="CodeSentToOtherDeviceInfo">登入驗證碼已發送至您其他設備上的 Telegram 應用。\n\n提示：如需透過郵箱接收驗證碼，請先在 Telegram 官方應用的「設定 > 隱私與安全 > 兩步驗證」中綁定「登錄郵箱」。</string>
+    <string name="SendCodeUnavailableInfo">Telegram 目前無法透過其他途徑發送驗證碼。若您其他設備已登入，請查看該設備收到的應用內驗證碼。\n\n如需使用郵箱登入，請確保已在 Telegram 的隱私與安全設定中綁定「登錄郵箱」。</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings_nia.xml
+++ b/TMessagesProj/src/main/res/values/strings_nia.xml
@@ -579,4 +579,10 @@
     <string name="UseFastestProxy">Switch to Fastest Proxy</string>
     <string name="SwitchedToFastestProxy">Switched to fastest proxy</string>
     <string name="AlreadyFastestProxy">Currently already using the fastest proxy</string>
+
+    <!-- Login Optimization -->
+    <string name="PrioritizeEmailCode">Prioritize email code</string>
+    <string name="FastResendDialogTitle">Resend Code</string>
+    <string name="FastResendDialogMessage">Haven\'t received the code yet? Skip the countdown and request a new code immediately?</string>
+    <string name="FastResendNow">Resend Now</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings_nia.xml
+++ b/TMessagesProj/src/main/res/values/strings_nia.xml
@@ -582,6 +582,7 @@
 
     <!-- Login Optimization -->
     <string name="PrioritizeEmailCode">Prioritize email code</string>
+    <string name="SendCodeViaEmail">Send code via email</string>
     <string name="FastResendDialogTitle">Resend Code</string>
     <string name="FastResendDialogMessage">Haven\'t received the code yet? Skip the countdown and request a new code immediately?</string>
     <string name="FastResendNow">Resend Now</string>

--- a/TMessagesProj/src/main/res/values/strings_nia.xml
+++ b/TMessagesProj/src/main/res/values/strings_nia.xml
@@ -586,4 +586,7 @@
     <string name="FastResendDialogTitle">Resend Code</string>
     <string name="FastResendDialogMessage">Haven\'t received the code yet? Skip the countdown and request a new code immediately?</string>
     <string name="FastResendNow">Resend Now</string>
+    <string name="CodeSentToOtherDeviceTitle">Check Your Telegram App</string>
+    <string name="CodeSentToOtherDeviceInfo">The login code was sent to the Telegram app on your other devices.\n\nNote: To receive login codes via email, you must first bind a Login Email in the official Telegram app under Settings > Privacy &amp; Security > Two-Step Verification.</string>
+    <string name="SendCodeUnavailableInfo">Telegram cannot send a code through other channels right now. If your other device is logged in, please check the code sent to your Telegram app.\n\nTo use email login, ensure you have set up a Login Email in Telegram\'s Privacy &amp; Security settings.</string>
 </resources>


### PR DESCRIPTION
## What's Changes
1. **Prioritize Email Verification Codes:**
- Added an optional checkbox in the phone number input interface.
- When checked, sending the `auth.sendCode` request will include the `request_email_code = true` flag (MTProto `codeSettings` flag 0).
- **Effect:** If the account has previously been linked to two-step verification or an email login, Telegram's server will directly send the 6-digit code to the email address, bypassing SMS verification and any associated SMS fees.
- **Non-intrusive:** Disabled by default, allowing regular users to still receive push notifications for verification codes on other devices where they are logged in.
2. **Captcha Timeout Bypass / Instant Resend (Fast Resend Bypass):**
- When a user clicks on the countdown text (e.g., "SmsAvailableIn") in the verification code input interface, a confirmation dialog box will appear.
- Immediately disable the local countdown timer after verification and call `auth.resendCode` without waiting 60-120 seconds. This allows for a quick switch to the next verification channel (SMS/voice).