### PR TITLE
feat: pure Kotlin/Java lightweight VLESS tunnel (WIP)

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -451,6 +451,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
 
         instance = this;
         ApplicationLoader.postInitApplication();
+        top.nkbe.niagram.vless.VlessManager.INSTANCE.init();
         AndroidUtilities.checkDisplaySize(this, getResources().getConfiguration());
         currentAccount = UserConfig.selectedAccount;
         registerReceiver(batteryReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));

--- a/TMessagesProj/src/main/java/org/telegram/ui/ProxyListActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProxyListActivity.java
@@ -193,7 +193,12 @@ public class ProxyListActivity extends BaseFragment implements NotificationCente
             if (proxyInfo != null && WebSocketHelper.proxyServer.equals(proxyInfo.address)) {
                 textView.setText(LocaleController.getString(R.string.PublicProxy));
             } else {
-                textView.setText(proxyInfo.address + ":" + proxyInfo.port);
+                String vlessRemark = top.nkbe.niagram.vless.VlessManager.getNodeRemark(proxyInfo);
+                if (vlessRemark != null && !vlessRemark.isEmpty()) {
+                    textView.setText("VLESS · " + vlessRemark);
+                } else {
+                    textView.setText(proxyInfo.address + ":" + proxyInfo.port);
+                }
             }
             currentInfo = proxyInfo;
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/ProxySettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProxySettingsActivity.java
@@ -616,6 +616,18 @@ public class ProxySettingsActivity extends BaseFragment {
                 }
             }
 
+            if (params == null && clipText.trim().toLowerCase().startsWith("vless://")) {
+                top.nkbe.niagram.vless.VlessConfig vlessConfig = top.nkbe.niagram.vless.VlessConfig.parse(clipText.trim());
+                if (vlessConfig != null) {
+                    top.nkbe.niagram.vless.VlessManager.INSTANCE.addOrUpdateNode(vlessConfig);
+                    pasteType = TYPE_SOCKS5;
+                    pasteFields[FIELD_IP] = "127.0.0.1";
+                    pasteFields[FIELD_PORT] = String.valueOf(top.nkbe.niagram.vless.VlessManager.DEFAULT_LOCAL_PORT);
+                    pasteFields[FIELD_USER] = top.nkbe.niagram.vless.VlessManager.VLESS_PROXY_USER_TAG;
+                    pasteFields[FIELD_PASSWORD] = vlessConfig.getId();
+                }
+            }
+
             if (params != null) {
                 for (int i = 0; i < params.length; i++) {
                     final String[] pair = params[i].split("=");

--- a/TMessagesProj/src/main/java/top/nkbe/niagram/utils/ProxyUtil.kt
+++ b/TMessagesProj/src/main/java/top/nkbe/niagram/utils/ProxyUtil.kt
@@ -59,6 +59,7 @@ object ProxyUtil {
 
     @JvmStatic
     fun registerNetworkCallback() {
+        top.nkbe.niagram.vless.VlessManager.init()
         if (networkCallbackRegistered) return
         networkCallbackRegistered = true
 
@@ -407,6 +408,24 @@ object ProxyUtil {
 
                     }
 
+                } else if (line.startsWith("vless://", ignoreCase = true)) {
+
+                    val vlessConfig = top.nkbe.niagram.vless.VlessConfig.parse(line)
+                    if (vlessConfig != null) {
+                        top.nkbe.niagram.vless.VlessManager.addOrUpdateNode(vlessConfig)
+                        val pInfo = SharedConfig.ProxyInfo(
+                            "127.0.0.1",
+                            top.nkbe.niagram.vless.VlessManager.DEFAULT_LOCAL_PORT,
+                            top.nkbe.niagram.vless.VlessManager.VLESS_PROXY_USER_TAG,
+                            vlessConfig.id,
+                            ""
+                        )
+                        proxies.add(pInfo)
+                    } else {
+                        error = true
+                        showToast(getString(R.string.BrokenLink) + ": Invalid VLESS URL")
+                    }
+
                 }
 
             }
@@ -434,6 +453,24 @@ object ProxyUtil {
 
                             }
 
+                        } else if (line.startsWith("vless://", ignoreCase = true)) {
+
+                            val vlessConfig = top.nkbe.niagram.vless.VlessConfig.parse(line)
+                            if (vlessConfig != null) {
+                                top.nkbe.niagram.vless.VlessManager.addOrUpdateNode(vlessConfig)
+                                val pInfo = SharedConfig.ProxyInfo(
+                                    "127.0.0.1",
+                                    top.nkbe.niagram.vless.VlessManager.DEFAULT_LOCAL_PORT,
+                                    top.nkbe.niagram.vless.VlessManager.VLESS_PROXY_USER_TAG,
+                                    vlessConfig.id,
+                                    ""
+                                )
+                                proxies.add(pInfo)
+                            } else {
+                                error = true
+                                showToast(getString(R.string.BrokenLink) + ": Invalid VLESS URL")
+                            }
+
                         }
 
                     }
@@ -452,7 +489,10 @@ object ProxyUtil {
 
         } else if (!error) {
 
-            AlertUtil.showSimpleAlert(ctx, getString(R.string.ImportedProxies) + "\n\n" + proxies.joinToString("\n") { it.address })
+            AlertUtil.showSimpleAlert(ctx, getString(R.string.ImportedProxies) + "\n\n" + proxies.joinToString("\n") {
+                val remark = top.nkbe.niagram.vless.VlessManager.getNodeRemark(it)
+                if (remark != null) "VLESS: $remark" else "${it.address}:${it.port}"
+            })
 
         }
 

--- a/TMessagesProj/src/main/java/top/nkbe/niagram/vless/VlessConfig.kt
+++ b/TMessagesProj/src/main/java/top/nkbe/niagram/vless/VlessConfig.kt
@@ -1,0 +1,215 @@
+package top.nkbe.niagram.vless
+
+import java.io.Serializable
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.ByteBuffer
+import java.util.UUID
+
+/**
+ * Configuration model and parser for VLESS nodes.
+ * Format: vless://[uuid]@[host]:[port]?[query]#[remarks]
+ */
+data class VlessConfig(
+    val id: String = UUID.randomUUID().toString(),
+    val uuid: String,
+    val host: String,
+    val port: Int = 443,
+    val remarks: String = "",
+    val security: String = "tls", // "tls" or "none"
+    val sni: String = "",
+    val flow: String = "",        // e.g. "xtls-rprx-vision"
+    val alpn: String = "",        // e.g. "h2,http/1.1"
+    val type: String = "tcp",     // "tcp"
+    val fingerprint: String = ""  // e.g. "chrome"
+) : Serializable {
+
+    val uuidBytes: ByteArray by lazy {
+        parseUuidToBytes(uuid)
+    }
+
+    /**
+     * Effective SNI: returns [sni] if non-empty, otherwise returns [host] if host is not an IP.
+     */
+    val effectiveSni: String
+        get() {
+            if (sni.isNotBlank()) return sni.trim()
+            val cleanHost = host.trim()
+            // If host looks like an IPv4 or IPv6, SNI should not default to it (RFC 6066)
+            if (isIpAddress(cleanHost)) return ""
+            return cleanHost
+        }
+
+    val isTls: Boolean
+        get() = security.equals("tls", ignoreCase = true)
+
+    val isVision: Boolean
+        get() = flow.equals("xtls-rprx-vision", ignoreCase = true)
+
+    fun toUri(): String {
+        val encodedRemarks = try {
+            URLEncoder.encode(remarks, "UTF-8")
+        } catch (_: Exception) {
+            remarks
+        }
+        val queryParams = mutableListOf<String>()
+        if (security.isNotBlank()) queryParams.add("security=${URLEncoder.encode(security, "UTF-8")}")
+        if (sni.isNotBlank()) queryParams.add("sni=${URLEncoder.encode(sni, "UTF-8")}")
+        if (flow.isNotBlank()) queryParams.add("flow=${URLEncoder.encode(flow, "UTF-8")}")
+        if (alpn.isNotBlank()) queryParams.add("alpn=${URLEncoder.encode(alpn, "UTF-8")}")
+        if (type.isNotBlank()) queryParams.add("type=${URLEncoder.encode(type, "UTF-8")}")
+        if (fingerprint.isNotBlank()) queryParams.add("fp=${URLEncoder.encode(fingerprint, "UTF-8")}")
+
+        val queryStr = if (queryParams.isNotEmpty()) "?" + queryParams.joinToString("&") else ""
+        val fragmentStr = if (encodedRemarks.isNotBlank()) "#$encodedRemarks" else ""
+
+        val formattedHost = if (host.contains(":") && !host.startsWith("[")) "[$host]" else host
+        return "vless://$uuid@$formattedHost:$port$queryStr$fragmentStr"
+    }
+
+    companion object {
+        private const val serialVersionUID = 1L
+
+        @JvmStatic
+        fun parseUuidToBytes(uuidStr: String): ByteArray {
+            val clean = uuidStr.replace("-", "").trim()
+            if (clean.length == 32) {
+                val bytes = ByteArray(16)
+                for (i in 0 until 16) {
+                    bytes[i] = clean.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+                }
+                return bytes
+            }
+            return try {
+                val u = UUID.fromString(uuidStr.trim())
+                val bb = ByteBuffer.wrap(ByteArray(16))
+                bb.putLong(u.mostSignificantBits)
+                bb.putLong(u.leastSignificantBits)
+                bb.array()
+            } catch (e: Exception) {
+                ByteArray(16)
+            }
+        }
+
+        @JvmStatic
+        fun isIpAddress(str: String): Boolean {
+            val s = str.trim().removePrefix("[").removeSuffix("]")
+            // Quick IPv4 check
+            val parts = s.split(".")
+            if (parts.size == 4 && parts.all { it.toIntOrNull() in 0..255 }) {
+                return true
+            }
+            // Quick IPv6 check
+            if (s.contains(":")) {
+                return true
+            }
+            return false
+        }
+
+        /**
+         * Parses a standard `vless://` URL.
+         * Example: vless://a1b2c3d4-0000-0000-0000-000000000000@example.com:443?security=tls&sni=example.com#MyNode
+         */
+        @JvmStatic
+        fun parse(rawUri: String): VlessConfig? {
+            val trimmed = rawUri.trim()
+            if (!trimmed.startsWith("vless://", ignoreCase = true)) {
+                return null
+            }
+
+            try {
+                var content = trimmed.substring("vless://".length)
+                var remarks = ""
+
+                // Extract fragment (#Remarks)
+                val hashIdx = content.indexOf('#')
+                if (hashIdx >= 0) {
+                    remarks = content.substring(hashIdx + 1)
+                    content = content.substring(0, hashIdx)
+                    remarks = try {
+                        URLDecoder.decode(remarks, "UTF-8")
+                    } catch (_: Exception) {
+                        remarks
+                    }
+                }
+
+                // Extract query parameters (?...)
+                val queryParams = mutableMapOf<String, String>()
+                val queryIdx = content.indexOf('?')
+                if (queryIdx >= 0) {
+                    val queryStr = content.substring(queryIdx + 1)
+                    content = content.substring(0, queryIdx)
+                    queryStr.split('&').forEach { param ->
+                        val eqIdx = param.indexOf('=')
+                        if (eqIdx > 0) {
+                            val key = param.substring(0, eqIdx).trim().lowercase()
+                            val value = try {
+                                URLDecoder.decode(param.substring(eqIdx + 1).trim(), "UTF-8")
+                            } catch (_: Exception) {
+                                param.substring(eqIdx + 1).trim()
+                            }
+                            queryParams[key] = value
+                        }
+                    }
+                }
+
+                // Parse userinfo (UUID) and host:port
+                val atIdx = content.lastIndexOf('@')
+                if (atIdx <= 0) return null
+
+                val uuid = content.substring(0, atIdx).trim()
+                var hostPort = content.substring(atIdx + 1).trim()
+
+                // Extract host and port, handling IPv6 like [2001:db8::1]:443
+                val host: String
+                val port: Int
+                if (hostPort.startsWith("[")) {
+                    val closeBracket = hostPort.indexOf(']')
+                    if (closeBracket <= 0) return null
+                    host = hostPort.substring(1, closeBracket)
+                    val afterBracket = hostPort.substring(closeBracket + 1)
+                    port = if (afterBracket.startsWith(":")) {
+                        afterBracket.substring(1).toIntOrNull() ?: 443
+                    } else {
+                        443
+                    }
+                } else {
+                    val colonIdx = hostPort.lastIndexOf(':')
+                    if (colonIdx >= 0) {
+                        host = hostPort.substring(0, colonIdx)
+                        port = hostPort.substring(colonIdx + 1).toIntOrNull() ?: 443
+                    } else {
+                        host = hostPort
+                        port = 443
+                    }
+                }
+
+                if (uuid.isBlank() || host.isBlank() || port !in 1..65535) {
+                    return null
+                }
+
+                val security = queryParams["security"] ?: "none"
+                val sni = queryParams["sni"] ?: ""
+                val flow = queryParams["flow"] ?: ""
+                val alpn = queryParams["alpn"] ?: ""
+                val type = queryParams["type"] ?: "tcp"
+                val fingerprint = queryParams["fp"] ?: ""
+
+                return VlessConfig(
+                    uuid = uuid,
+                    host = host,
+                    port = port,
+                    remarks = if (remarks.isNotBlank()) remarks else "$host:$port",
+                    security = security,
+                    sni = sni,
+                    flow = flow,
+                    alpn = alpn,
+                    type = type,
+                    fingerprint = fingerprint
+                )
+            } catch (e: Exception) {
+                return null
+            }
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/top/nkbe/niagram/vless/VlessManager.kt
+++ b/TMessagesProj/src/main/java/top/nkbe/niagram/vless/VlessManager.kt
@@ -1,0 +1,220 @@
+package top.nkbe.niagram.vless
+
+import android.app.Activity
+import android.content.Context
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import org.telegram.messenger.AndroidUtilities
+import org.telegram.messenger.ApplicationLoader
+import org.telegram.messenger.FileLog
+import org.telegram.messenger.NotificationCenter
+import org.telegram.messenger.SharedConfig
+
+/**
+ * Manager responsible for:
+ * 1. Persisting VLESS configurations in SharedPreferences.
+ * 2. Managing the lifecycle of VlessServer.
+ * 3. Synchronizing VLESS tunnel state with Telegram's SharedConfig.currentProxy.
+ */
+object VlessManager : NotificationCenter.NotificationCenterDelegate {
+
+    private const val PREFS_NAME = "vless_config_prefs"
+    private const val KEY_NODES = "nodes_json"
+    private const val KEY_ACTIVE_NODE_ID = "active_node_id"
+    const val VLESS_PROXY_USER_TAG = "VLESS"
+    const val DEFAULT_LOCAL_PORT = 10853
+
+    private val gson = Gson()
+    private val vlessServer = VlessServer()
+
+    private var initialized = false
+
+    val isRunning: Boolean
+        get() = vlessServer.isRunning
+
+    val localPort: Int
+        get() = vlessServer.localPort
+
+    private val prefs: SharedPreferences by lazy {
+        ApplicationLoader.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    fun init() {
+        if (initialized) return
+        initialized = true
+
+        AndroidUtilities.runOnUIThread {
+            NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.proxySettingsChanged)
+        }
+
+        // Auto-resume tunnel if Telegram proxy is currently enabled and points to VLESS
+        checkAndResumeTunnel()
+    }
+
+    override fun didReceivedNotification(id: Int, account: Int, vararg args: Any?) {
+        if (id == NotificationCenter.proxySettingsChanged) {
+            val current = SharedConfig.currentProxy
+            val enabled = SharedConfig.isProxyEnabled()
+
+            if (!enabled || current == null || !isVlessProxy(current)) {
+                // User disabled proxy or switched to another proxy
+                if (vlessServer.isRunning) {
+                    FileLog.d("VlessManager: proxy turned off or non-VLESS proxy selected, stopping server")
+                    vlessServer.stop()
+                }
+            } else if (isVlessProxy(current) && (!vlessServer.isRunning || vlessServer.localPort != current.port)) {
+                // User re-enabled VLESS proxy or selected another VLESS node
+                val node = getNodeById(current.password) ?: getActiveNode()
+                if (node != null) {
+                    startTunnel(node, preferredPort = if (current.port > 0) current.port else DEFAULT_LOCAL_PORT)
+                }
+            }
+        }
+    }
+
+    fun getNodes(): List<VlessConfig> {
+        val json = prefs.getString(KEY_NODES, null) ?: return emptyList()
+        return try {
+            val type = object : TypeToken<List<VlessConfig>>() {}.type
+            gson.fromJson<List<VlessConfig>>(json, type) ?: emptyList()
+        } catch (e: Exception) {
+            FileLog.e("VlessManager: failed to parse nodes json", e)
+            emptyList()
+        }
+    }
+
+    @Synchronized
+    fun saveNodes(nodes: List<VlessConfig>) {
+        val json = gson.toJson(nodes)
+        prefs.edit().putString(KEY_NODES, json).apply()
+    }
+
+    @Synchronized
+    fun addOrUpdateNode(config: VlessConfig): VlessConfig {
+        val nodes = getNodes().toMutableList()
+        val index = nodes.indexOfFirst { it.id == config.id || (it.host == config.host && it.port == config.port && it.uuid == config.uuid) }
+        if (index >= 0) {
+            nodes[index] = config
+        } else {
+            nodes.add(0, config)
+        }
+        saveNodes(nodes)
+        return config
+    }
+
+    @Synchronized
+    fun deleteNode(nodeId: String) {
+        val nodes = getNodes().toMutableList()
+        nodes.removeAll { it.id == nodeId }
+        saveNodes(nodes)
+
+        if (getActiveNodeId() == nodeId) {
+            setActiveNodeId(null)
+            if (vlessServer.isRunning) {
+                stopTunnel()
+            }
+        }
+    }
+
+    fun getNodeById(nodeId: String?): VlessConfig? {
+        if (nodeId.isNullOrBlank()) return null
+        return getNodes().find { it.id == nodeId }
+    }
+
+    fun getActiveNodeId(): String? {
+        return prefs.getString(KEY_ACTIVE_NODE_ID, null)
+    }
+
+    private fun setActiveNodeId(id: String?) {
+        prefs.edit().putString(KEY_ACTIVE_NODE_ID, id).apply()
+    }
+
+    fun getActiveNode(): VlessConfig? {
+        val id = getActiveNodeId() ?: return null
+        return getNodeById(id)
+    }
+
+    /**
+     * Checks if a [SharedConfig.ProxyInfo] represents a VLESS tunnel managed by [VlessManager].
+     */
+    @JvmStatic
+    fun isVlessProxy(proxyInfo: SharedConfig.ProxyInfo?): Boolean {
+        if (proxyInfo == null) return false
+        return proxyInfo.username == VLESS_PROXY_USER_TAG ||
+                (proxyInfo.address == "127.0.0.1" && proxyInfo.port == vlessServer.localPort && vlessServer.localPort > 0)
+    }
+
+    /**
+     * Retrieves the friendly display name for a VLESS proxy item in ProxyList.
+     */
+    @JvmStatic
+    fun getNodeRemark(proxyInfo: SharedConfig.ProxyInfo?): String? {
+        if (!isVlessProxy(proxyInfo)) return null
+        val nodeId = proxyInfo?.password
+        val node = getNodeById(nodeId) ?: getActiveNode()
+        return node?.remarks
+    }
+
+    /**
+     * Starts the VLESS tunnel for the given node and configures Telegram's currentProxy.
+     */
+    @Synchronized
+    fun startTunnel(config: VlessConfig, preferredPort: Int = DEFAULT_LOCAL_PORT): Int {
+        try {
+            val port = vlessServer.start(config, preferredPort)
+            setActiveNodeId(config.id)
+
+            // Register with Telegram's proxy manager
+            val proxyInfo = SharedConfig.ProxyInfo(
+                "127.0.0.1",
+                port,
+                VLESS_PROXY_USER_TAG,
+                config.id, // Store config ID in password for retrieval
+                ""         // Empty secret denotes SOCKS5
+            )
+
+            AndroidUtilities.runOnUIThread {
+                val addedInfo = SharedConfig.addProxy(proxyInfo)
+                SharedConfig.currentProxy = addedInfo
+                SharedConfig.setProxyEnable(true)
+                NotificationCenter.getGlobalInstance().postNotificationName(NotificationCenter.proxySettingsChanged)
+            }
+
+            FileLog.d("VlessManager: tunnel started on port $port for node ${config.remarks}")
+            return port
+        } catch (e: Exception) {
+            FileLog.e("VlessManager: failed to start tunnel", e)
+            throw e
+        }
+    }
+
+    /**
+     * Stops the VLESS tunnel and disables Telegram proxy if currentProxy is VLESS.
+     */
+    @Synchronized
+    fun stopTunnel() {
+        vlessServer.stop()
+        setActiveNodeId(null)
+
+        AndroidUtilities.runOnUIThread {
+            if (isVlessProxy(SharedConfig.currentProxy)) {
+                SharedConfig.setProxyEnable(false)
+                NotificationCenter.getGlobalInstance().postNotificationName(NotificationCenter.proxySettingsChanged)
+            }
+        }
+    }
+
+    private fun checkAndResumeTunnel() {
+        try {
+            if (SharedConfig.isProxyEnabled() && isVlessProxy(SharedConfig.currentProxy)) {
+                val activeNode = getActiveNode()
+                if (activeNode != null && !vlessServer.isRunning) {
+                    startTunnel(activeNode)
+                }
+            }
+        } catch (e: Exception) {
+            FileLog.e("VlessManager: error during checkAndResumeTunnel", e)
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/top/nkbe/niagram/vless/VlessProtocol.kt
+++ b/TMessagesProj/src/main/java/top/nkbe/niagram/vless/VlessProtocol.kt
@@ -1,0 +1,186 @@
+package top.nkbe.niagram.vless
+
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.InputStream
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.ProtocolException
+
+/**
+ * VLESS protocol byte serializer and response parser.
+ * Wire format adheres strictly to Xray-core / v2fly / sing-box standards.
+ */
+object VlessProtocol {
+
+    const val VERSION: Byte = 0x00
+
+    const val CMD_TCP: Byte = 0x01
+    const val CMD_UDP: Byte = 0x02
+    const val CMD_MUX: Byte = 0x03
+
+    const val ADDR_TYPE_IPV4: Byte = 0x01
+    const val ADDR_TYPE_DOMAIN: Byte = 0x02
+    const val ADDR_TYPE_IPV6: Byte = 0x03
+
+    // SOCKS5 RFC 1928 Address Types
+    const val SOCKS5_ATYP_IPV4: Byte = 0x01
+    const val SOCKS5_ATYP_DOMAIN: Byte = 0x03
+    const val SOCKS5_ATYP_IPV6: Byte = 0x04
+
+    /**
+     * Builds a VLESS Request Header from target host and port.
+     */
+    @JvmStatic
+    fun buildRequestHeader(
+        uuidBytes: ByteArray,
+        targetHost: String,
+        targetPort: Int,
+        command: Byte = CMD_TCP
+    ): ByteArray {
+        require(uuidBytes.size == 16) { "UUID must be exactly 16 bytes" }
+        require(targetPort in 1..65535) { "Invalid port: $targetPort" }
+
+        val cleanHost = targetHost.trim().removePrefix("[").removeSuffix("]")
+        val baos = ByteArrayOutputStream(64)
+        val dos = DataOutputStream(baos)
+
+        // 1. Version (1 byte)
+        dos.writeByte(VERSION.toInt())
+
+        // 2. User ID (16 bytes)
+        dos.write(uuidBytes)
+
+        // 3. Addon length (1 byte) - 0 indicates no addons (standard TLS mode)
+        dos.writeByte(0)
+
+        // 4. Command (1 byte) - 0x01 for TCP
+        dos.writeByte(command.toInt())
+
+        // 5. Port (2 bytes, Big-Endian)
+        dos.writeShort(targetPort)
+
+        // 6. Address Type & Address
+        val inetAddr = try {
+            if (VlessConfig.isIpAddress(cleanHost)) InetAddress.getByName(cleanHost) else null
+        } catch (_: Exception) {
+            null
+        }
+
+        when (inetAddr) {
+            is Inet4Address -> {
+                dos.writeByte(ADDR_TYPE_IPV4.toInt())
+                dos.write(inetAddr.address)
+            }
+            is Inet6Address -> {
+                dos.writeByte(ADDR_TYPE_IPV6.toInt())
+                dos.write(inetAddr.address)
+            }
+            else -> {
+                // Domain
+                val domainBytes = cleanHost.toByteArray(Charsets.US_ASCII)
+                require(domainBytes.size <= 255) { "Domain name too long: $cleanHost" }
+                dos.writeByte(ADDR_TYPE_DOMAIN.toInt())
+                dos.writeByte(domainBytes.size)
+                dos.write(domainBytes)
+            }
+        }
+
+        dos.flush()
+        return baos.toByteArray()
+    }
+
+    /**
+     * Builds a VLESS Request Header directly from SOCKS5 CONNECT parameters.
+     * Note: In SOCKS5, DOMAIN is atyp 0x03 (1 byte length + ASCII), IPV6 is atyp 0x04 (16 bytes).
+     * In VLESS, DOMAIN is 0x02, IPV6 is 0x03.
+     */
+    @JvmStatic
+    fun buildRequestHeaderFromSocks5(
+        uuidBytes: ByteArray,
+        socks5Atyp: Byte,
+        rawAddressBytes: ByteArray,
+        targetPort: Int,
+        command: Byte = CMD_TCP
+    ): ByteArray {
+        require(uuidBytes.size == 16) { "UUID must be exactly 16 bytes" }
+        require(targetPort in 1..65535) { "Invalid port: $targetPort" }
+
+        val baos = ByteArrayOutputStream(64)
+        val dos = DataOutputStream(baos)
+
+        // 1. Version
+        dos.writeByte(VERSION.toInt())
+        // 2. User ID
+        dos.write(uuidBytes)
+        // 3. Addon length
+        dos.writeByte(0)
+        // 4. Command
+        dos.writeByte(command.toInt())
+        // 5. Port
+        dos.writeShort(targetPort)
+
+        // 6. Address
+        when (socks5Atyp) {
+            SOCKS5_ATYP_IPV4 -> {
+                require(rawAddressBytes.size == 4) { "IPv4 address must be 4 bytes" }
+                dos.writeByte(ADDR_TYPE_IPV4.toInt())
+                dos.write(rawAddressBytes)
+            }
+            SOCKS5_ATYP_DOMAIN -> {
+                // In SOCKS5, rawAddressBytes already includes [1-byte length + ASCII bytes] OR only ASCII bytes
+                // We handle both:
+                dos.writeByte(ADDR_TYPE_DOMAIN.toInt())
+                if (rawAddressBytes.isNotEmpty()) {
+                    val firstByte = rawAddressBytes[0].toInt() and 0xFF
+                    if (rawAddressBytes.size == firstByte + 1) {
+                        // Already formatted as [length, string...]
+                        dos.write(rawAddressBytes)
+                    } else {
+                        // Raw string bytes
+                        dos.writeByte(rawAddressBytes.size)
+                        dos.write(rawAddressBytes)
+                    }
+                } else {
+                    dos.writeByte(0)
+                }
+            }
+            SOCKS5_ATYP_IPV6 -> {
+                require(rawAddressBytes.size == 16) { "IPv6 address must be 16 bytes" }
+                dos.writeByte(ADDR_TYPE_IPV6.toInt())
+                dos.write(rawAddressBytes)
+            }
+            else -> throw ProtocolException("Unsupported SOCKS5 ATYP: $socks5Atyp")
+        }
+
+        dos.flush()
+        return baos.toByteArray()
+    }
+
+    /**
+     * Reads and validates the VLESS Response Header from the remote server.
+     * Throws [ProtocolException] if the version doesn't match.
+     */
+    @JvmStatic
+    @Throws(Exception::class)
+    fun readResponseHeader(inputStream: InputStream) {
+        val dis = DataInputStream(inputStream)
+        val version = dis.readByte()
+        if (version != VERSION) {
+            throw ProtocolException("Unexpected VLESS response version: $version (expected $VERSION)")
+        }
+
+        val addonsLen = dis.readByte().toInt() and 0xFF
+        if (addonsLen > 0) {
+            val skipped = dis.skipBytes(addonsLen)
+            if (skipped < addonsLen) {
+                // In case skipBytes skipped fewer bytes
+                val remaining = addonsLen - skipped
+                val buf = ByteArray(remaining)
+                dis.readFully(buf)
+            }
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/top/nkbe/niagram/vless/VlessServer.kt
+++ b/TMessagesProj/src/main/java/top/nkbe/niagram/vless/VlessServer.kt
@@ -1,0 +1,374 @@
+package top.nkbe.niagram.vless
+
+import org.telegram.messenger.FileLog
+import java.io.Closeable
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import javax.net.ssl.SNIHostName
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+import kotlin.concurrent.thread
+
+/**
+ * Lightweight pure Kotlin/Java VLESS Tunnel Server.
+ * Runs a local SOCKS5 listener (127.0.0.1:localPort) and bridges Telegram's connections
+ * to the remote VLESS server over standard TLS.
+ *
+ * Design principles:
+ * 1. 0% CPU consumption during idle: ServerSocket.accept() and socket reads block strictly
+ *    in OS kernel without any polling or busy loops.
+ * 2. Instant cleanup: Closing the server closes all active client and remote sockets,
+ *    immediately unblocking threads and freeing file descriptors.
+ */
+class VlessServer : Closeable {
+
+    private val isRunningState = AtomicBoolean(false)
+    private var serverSocket: ServerSocket? = null
+    private var acceptThread: Thread? = null
+
+    private val activeSockets = ConcurrentHashMap.newKeySet<Socket>()
+    private val connectionCounter = AtomicInteger(0)
+
+    val isRunning: Boolean
+        get() = isRunningState.get()
+
+    val localPort: Int
+        get() = serverSocket?.localPort ?: 0
+
+    val activeConnectionCount: Int
+        get() = activeSockets.size / 2 // 2 sockets per tunnel (client + remote)
+
+    /**
+     * Starts the local SOCKS5 server bound to 127.0.0.1.
+     * @param config The VLESS node configuration.
+     * @param preferredPort Preferred local port (0 for random available port).
+     * @return The bound local port.
+     */
+    @Synchronized
+    fun start(config: VlessConfig, preferredPort: Int = 0): Int {
+        if (isRunningState.get()) {
+            stop()
+        }
+
+        val sSocket = ServerSocket()
+        sSocket.reuseAddress = true
+        try {
+            sSocket.bind(InetSocketAddress(InetAddress.getByName("127.0.0.1"), preferredPort))
+        } catch (e: Exception) {
+            if (preferredPort != 0) {
+                FileLog.d("VlessServer: preferred port $preferredPort occupied, falling back to random port")
+                sSocket.bind(InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0))
+            } else {
+                throw e
+            }
+        }
+        serverSocket = sSocket
+        isRunningState.set(true)
+
+        val port = sSocket.localPort
+        FileLog.d("VlessServer: started on 127.0.0.1:$port for target ${config.host}:${config.port}")
+
+        val t = thread(name = "VlessServer-Accept", isDaemon = true) {
+            acceptLoop(sSocket, config)
+        }
+        acceptThread = t
+
+        return port
+    }
+
+    /**
+     * Stops the server and closes all active client and remote sockets.
+     */
+    @Synchronized
+    fun stop() {
+        if (!isRunningState.compareAndSet(true, false)) {
+            return
+        }
+
+        FileLog.d("VlessServer: stopping server...")
+
+        try {
+            serverSocket?.close()
+        } catch (_: Exception) {}
+        serverSocket = null
+
+        acceptThread?.interrupt()
+        acceptThread = null
+
+        // Close all active sockets to terminate all blocking pipes immediately
+        val socketsToClose = activeSockets.toList()
+        activeSockets.clear()
+        for (sock in socketsToClose) {
+            try {
+                sock.close()
+            } catch (_: Exception) {}
+        }
+
+        FileLog.d("VlessServer: stopped and cleaned up ${socketsToClose.size} sockets")
+    }
+
+    override fun close() {
+        stop()
+    }
+
+    private fun acceptLoop(sSocket: ServerSocket, config: VlessConfig) {
+        while (isRunningState.get()) {
+            try {
+                val clientSocket = sSocket.accept()
+                clientSocket.tcpNoDelay = true
+                trackSocket(clientSocket)
+
+                val connId = connectionCounter.incrementAndGet()
+                thread(name = "VlessConn-$connId", isDaemon = true) {
+                    handleConnection(clientSocket, config)
+                }
+            } catch (e: SocketException) {
+                // Expected when ServerSocket is closed
+                break
+            } catch (e: Throwable) {
+                if (isRunningState.get()) {
+                    FileLog.e("VlessServer: accept error", e)
+                }
+                break
+            }
+        }
+    }
+
+    private fun trackSocket(socket: Socket) {
+        activeSockets.add(socket)
+    }
+
+    private fun untrackSocket(socket: Socket) {
+        activeSockets.remove(socket)
+    }
+
+    private fun handleConnection(clientSocket: Socket, config: VlessConfig) {
+        var remoteSocket: Socket? = null
+        try {
+            val clientIn = DataInputStream(clientSocket.getInputStream())
+            val clientOut = DataOutputStream(clientSocket.getOutputStream())
+
+            // 1. SOCKS5 Handshake: Greeting
+            val socksVersion = clientIn.readByte().toInt() and 0xFF
+            if (socksVersion != 0x05) {
+                return
+            }
+            val numMethods = clientIn.readByte().toInt() and 0xFF
+            val methods = ByteArray(numMethods)
+            clientIn.readFully(methods)
+
+            // Reply: Version 5, Method 0 (NO_AUTHENTICATION_REQUIRED)
+            clientOut.write(byteArrayOf(0x05, 0x00))
+            clientOut.flush()
+
+            // 2. SOCKS5 Handshake: Connection Request
+            val reqVersion = clientIn.readByte().toInt() and 0xFF
+            val cmd = clientIn.readByte().toInt() and 0xFF
+            val rsv = clientIn.readByte()
+            val atyp = clientIn.readByte()
+
+            if (reqVersion != 0x05 || cmd != 0x01) { // 0x01 is CONNECT
+                // Reply: Command not supported (0x07)
+                clientOut.write(byteArrayOf(0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0))
+                clientOut.flush()
+                return
+            }
+
+            // Read target address bytes based on ATYP
+            val rawAddrBytes = when (atyp) {
+                VlessProtocol.SOCKS5_ATYP_IPV4 -> {
+                    val addr = ByteArray(4)
+                    clientIn.readFully(addr)
+                    addr
+                }
+                VlessProtocol.SOCKS5_ATYP_DOMAIN -> {
+                    val len = clientIn.readByte().toInt() and 0xFF
+                    val domainBytes = ByteArray(len)
+                    clientIn.readFully(domainBytes)
+                    // Prepend length byte for consistency with buildRequestHeaderFromSocks5
+                    val result = ByteArray(len + 1)
+                    result[0] = len.toByte()
+                    System.arraycopy(domainBytes, 0, result, 1, len)
+                    result
+                }
+                VlessProtocol.SOCKS5_ATYP_IPV6 -> {
+                    val addr = ByteArray(16)
+                    clientIn.readFully(addr)
+                    addr
+                }
+                else -> {
+                    // Address type not supported (0x08)
+                    clientOut.write(byteArrayOf(0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0))
+                    clientOut.flush()
+                    return
+                }
+            }
+
+            val targetPort = clientIn.readUnsignedShort()
+
+            // 3. Connect to remote VLESS server
+            val remote = dialRemote(config)
+            remoteSocket = remote
+            trackSocket(remote)
+
+            val remoteOut = remote.getOutputStream()
+            val remoteIn = remote.getInputStream()
+
+            // 4. Send VLESS Request Header
+            val vlessHeader = VlessProtocol.buildRequestHeaderFromSocks5(
+                uuidBytes = config.uuidBytes,
+                socks5Atyp = atyp,
+                rawAddressBytes = rawAddrBytes,
+                targetPort = targetPort,
+                command = VlessProtocol.CMD_TCP
+            )
+            remoteOut.write(vlessHeader)
+            remoteOut.flush()
+
+            // 5. Read VLESS Response Header
+            VlessProtocol.readResponseHeader(remoteIn)
+
+            // 6. SOCKS5 Reply: Success (0x00)
+            // 0x05, 0x00 (success), 0x00 (RSV), 0x01 (IPv4), BND.ADDR=0.0.0.0, BND.PORT=0
+            clientOut.write(byteArrayOf(0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0))
+            clientOut.flush()
+
+            // 7. Full-Duplex Bidirectional Pipe
+            bridgeSockets(clientSocket, remote)
+
+        } catch (e: Exception) {
+            if (isRunningState.get()) {
+                // SOCKS5 reply failure if client socket is still open
+                try {
+                    val clientOut = clientSocket.getOutputStream()
+                    clientOut.write(byteArrayOf(0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0)) // 0x05 = Connection refused
+                    clientOut.flush()
+                } catch (_: Exception) {}
+            }
+        } finally {
+            untrackSocket(clientSocket)
+            try {
+                clientSocket.close()
+            } catch (_: Exception) {}
+
+            if (remoteSocket != null) {
+                untrackSocket(remoteSocket)
+                try {
+                    remoteSocket.close()
+                } catch (_: Exception) {}
+            }
+        }
+    }
+
+    /**
+     * Dials the remote VLESS endpoint, establishing standard TLS if configured.
+     */
+    private fun dialRemote(config: VlessConfig): Socket {
+        val baseSocket = Socket()
+        baseSocket.tcpNoDelay = true
+        baseSocket.soTimeout = 0 // Keep-alive / no read timeout for long-lived DC connections
+        baseSocket.connect(InetSocketAddress(config.host, config.port), CONNECT_TIMEOUT_MS)
+
+        if (!config.isTls) {
+            return baseSocket
+        }
+
+        val sslFactory = SSLSocketFactory.getDefault() as SSLSocketFactory
+        val sslSocket = sslFactory.createSocket(
+            baseSocket,
+            config.host,
+            config.port,
+            true
+        ) as SSLSocket
+
+        // Inject SNI
+        val sniHost = config.effectiveSni
+        if (sniHost.isNotBlank()) {
+            try {
+                val params = sslSocket.sslParameters
+                params.serverNames = listOf(SNIHostName(sniHost))
+                sslSocket.sslParameters = params
+            } catch (e: Throwable) {
+                FileLog.e("VlessServer: failed to set SNI $sniHost", e)
+            }
+        }
+
+        // Enable standard modern TLS protocols
+        try {
+            val supportedProtocols = sslSocket.supportedProtocols
+            val targetProtocols = mutableListOf<String>()
+            if ("TLSv1.3" in supportedProtocols) targetProtocols.add("TLSv1.3")
+            if ("TLSv1.2" in supportedProtocols) targetProtocols.add("TLSv1.2")
+            if (targetProtocols.isNotEmpty()) {
+                sslSocket.enabledProtocols = targetProtocols.toTypedArray()
+            }
+        } catch (_: Throwable) {}
+
+        sslSocket.startHandshake()
+        return sslSocket
+    }
+
+    /**
+     * Bidirectional blocking stream relay with direct byte copying.
+     * When one direction terminates (EOF or error), both sockets are closed.
+     */
+    private fun bridgeSockets(client: Socket, remote: Socket) {
+        val clientIn = client.getInputStream()
+        val clientOut = client.getOutputStream()
+        val remoteIn = remote.getInputStream()
+        val remoteOut = remote.getOutputStream()
+
+        val t1 = thread(name = "VlessRelay-Up", isDaemon = true) {
+            pipeStream(clientIn, remoteOut)
+            try {
+                remote.shutdownOutput()
+            } catch (_: Exception) {
+                try { remote.close() } catch (_: Exception) {}
+            }
+        }
+
+        val t2 = thread(name = "VlessRelay-Down", isDaemon = true) {
+            pipeStream(remoteIn, clientOut)
+            try {
+                client.shutdownOutput()
+            } catch (_: Exception) {
+                try { client.close() } catch (_: Exception) {}
+            }
+        }
+
+        t1.join()
+        t2.join()
+    }
+
+    private fun pipeStream(input: InputStream, output: OutputStream) {
+        val buffer = ByteArray(BUFFER_SIZE)
+        try {
+            while (isRunningState.get()) {
+                val bytesRead = input.read(buffer)
+                if (bytesRead < 0) break
+                output.write(buffer, 0, bytesRead)
+                output.flush()
+            }
+        } catch (_: SocketException) {
+            // Normal connection teardown
+        } catch (_: IOException) {
+            // Normal connection teardown
+        }
+    }
+
+    companion object {
+        private const val CONNECT_TIMEOUT_MS = 10_000
+        private const val BUFFER_SIZE = 16 * 1024 // 16 KB buffer optimal for throughput vs heap
+    }
+}


### PR DESCRIPTION
### 纯 Kotlin/Java 轻量级 VLESS 隧道方案 (WIP)

#### 动机
针对此前引入完整 Go 内核带来的后台功耗高（Go sysmon 唤醒导致无法深睡）、LMK 频杀以及包体积增加等痛点，构建一套直接基于应用内 SOCKS5 桥接与 Android 原生 TLS 1.3/1.2 的轻量级 VLESS 隧道。

#### 本分支改动
1. **协议层 (	op.nkbe.niagram.vless)**：
   - \VlessConfig\: 标准 \less://\ 链接解析器与 UUID 16 字节转换。
   - \VlessProtocol\: 纯 Kotlin 二进制 VLESS 请求头组装与响应头校验。
   - \VlessServer\: 本地 SOCKS5 监听服务，采用内核级真阻塞 IO（0 轮询）配合系统原生 Conscrypt/BoringSSL \SSLSocket\ 进行透明双向透传。
   - \VlessManager\: 节点持久化存储，并与 Telegram \SharedConfig.currentProxy\ 及 \ConnectionsManager\ 自动联动生命周期。
2. **UI 与剪贴板对接**：
   - \ProxyUtil.importFromClipboard\: 支持识别剪贴板中的 \less://\ 链接并一键导入节点。
   - \ProxyListActivity\: 识别 VLESS 节点并在列表中展示节点备注名 (\VLESS · Remark\)。
   - \ProxySettingsActivity\: 剪贴板识别并填充。
   - \LaunchActivity\: 启动时初始化 \VlessManager\。

*注：目前在真机环境下尚待进一步排查调优，先以独立分支及 PR 形式归档与跟进。*